### PR TITLE
OD-12026: Add comments to openrtb-xapi.proto

### DIFF
--- a/com/magnite/openrtb/v2/openrtb-xapi.proto
+++ b/com/magnite/openrtb/v2/openrtb-xapi.proto
@@ -24,7 +24,7 @@ message Window {
     optional string url = 1;
 
     // The iframe depth.
-    optional int32  depth = 2;
+    optional int32 depth = 2;
 
     // Minimum width of any iframe traversed between the video player and window.top.
     optional uint32 w = 3;


### PR DESCRIPTION
Many of the comments come from the [spec in the Resource Center](https://resources.rubiconproject.com/resource/publisher-resources/xapi-specifications). Comments for fields not listed in the spec come from AE code, tickets, and other documentation.