### PR TITLE
OD-15721: Mark native size_id as deprecated

### DIFF
--- a/src/proto/com/magnite/openrtb/v2/openrtb-xapi.proto
+++ b/src/proto/com/magnite/openrtb/v2/openrtb-xapi.proto
@@ -86,10 +86,10 @@ message ImpExt {
         // RTB rule price floor.
         optional double price = 2;
 
-        // DEPRECATED: NO LONGER SUPPORTED
+        // DEPRECATED: no longer supported
         // Flag to indicate whether or not Dynamic Price Floors should be active
         // for this floor.
-        optional bool dpf = 3;
+        optional bool dpf = 3 [deprecated = true];
 
         // RTB rule private marketplace (PMP) tier, where 1 and 2 are reserved
         // for future use, 3 = Private marketplace, 4 = First Right marketplace.
@@ -196,10 +196,10 @@ message VideoExt {
     optional Ad ad = 3;
 
     // DEPRECATED: Use “skip” field from the video object.
-    optional bool skip = 4;
+    optional bool skip = 4 [deprecated = true];
 
     // DEPRECATED: Replaced by “skipafter” in the video object.
-    optional int32 skipdelay = 5;
+    optional int32 skipdelay = 5 [deprecated = true];
 
     // Placement type for the impression. Refer to IAB OpenRTB
     // VideoPlacementType enum.
@@ -228,10 +228,10 @@ message BannerExt {
         // fragment.
         optional string mime = 3;
 
-        // DEPRECATED: NO LONGER SUPPORTED
+        // DEPRECATED: no longer supported
         // Flag to indicate usage of nurl (Magnite billable pixel) in
         // bid response.
-        optional bool usenurl = 4;
+        optional bool usenurl = 4 [deprecated = true];
 
         // Flag to indicate usage of imptrackers (DSP impression tracking
         // pixels) in bid response.
@@ -404,7 +404,7 @@ message UserExt {
     }
 
     // DEPRECATED: DigiTrust user ID and context.
-    optional Dt dt = 1;
+    optional Dt dt = 1 [deprecated = true];
 
     // Additions specific to DV+.
     optional Rp rp = 3;
@@ -444,10 +444,10 @@ extend com.iabtechlab.openrtb.v2.BidRequest.Source {
 
 message NativeExt {
     message Rp {
-        // DEPRECATED: NO LONGER SUPPORTED
+        // DEPRECATED: no longer supported
         // DV+ size ID. Refer to
         // https://resources.rubiconproject.com/resource/publisher-resources-2/supported-ad-formats.
-        optional uint32 deprecated_size_id = 1;
+        optional uint32 size_id = 1  [deprecated = true];
     }
 
     // Additions specific to DV+.
@@ -543,8 +543,8 @@ message BidExt {
         // Bid price net of all fees.
         optional double adjustbid = 9;
 
-        // Temporary field to allow for transition period moving from string to int
-        optional string deprecated_pmptier = 10;
+        // DEPRECATED: Temporary field to allow for transition period moving from string to int
+        optional string deprecated_pmptier = 10  [deprecated = true];
 
         // RTB ad quality ID.
         optional string aqid = 11;

--- a/src/proto/com/magnite/openrtb/v2/openrtb-xapi.proto
+++ b/src/proto/com/magnite/openrtb/v2/openrtb-xapi.proto
@@ -447,7 +447,7 @@ message NativeExt {
         // DEPRECATED: no longer supported
         // DV+ size ID. Refer to
         // https://resources.rubiconproject.com/resource/publisher-resources-2/supported-ad-formats.
-        optional uint32 size_id = 1  [deprecated = true];
+        optional uint32 size_id = 1 [deprecated = true];
     }
 
     // Additions specific to DV+.
@@ -544,7 +544,7 @@ message BidExt {
         optional double adjustbid = 9;
 
         // DEPRECATED: Temporary field to allow for transition period moving from string to int
-        optional string deprecated_pmptier = 10  [deprecated = true];
+        optional string deprecated_pmptier = 10 [deprecated = true];
 
         // RTB ad quality ID.
         optional string aqid = 11;

--- a/src/proto/com/magnite/openrtb/v2/openrtb-xapi.proto
+++ b/src/proto/com/magnite/openrtb/v2/openrtb-xapi.proto
@@ -151,8 +151,8 @@ message ImpExt {
     // https://resources.rubiconproject.com/resource/publisher-resources/xapi-specifications/#4.9.
     repeated string viewabilityvendors = 3;
 
-    // Global Placement ID. The unique identifier of the placement that is sent 
-    // to all participants in buying impressions for this placement. In general, 
+    // Global Placement ID. The unique identifier of the placement that is sent
+    // to all participants in buying impressions for this placement. In general,
     // this field will be populated with one of the DFP Ad Unit Code, Prebid Ad Slot,
     // or value provided by the publisher or ad server.
     optional string gpid = 4;
@@ -438,9 +438,10 @@ extend com.iabtechlab.openrtb.v2.BidRequest.Source {
 
 message NativeExt {
     message Rp {
+        // DEPRECATED: NO LONGER SUPPORTED
         // DV+ size ID. Refer to
         // https://resources.rubiconproject.com/resource/publisher-resources-2/supported-ad-formats.
-        optional uint32 size_id = 1;
+        optional uint32 deprecated_size_id = 1;
     }
 
     // Additions specific to DV+.


### PR DESCRIPTION
Changes:
- Deprecate `$.imp.native.ext.rp.size_id`
- Standardize handling of deprecated fields
    - Following IAB convention, add `deprecated` tag
    - Don't add `deprecated_` prefix to deprecated fields unless necessary